### PR TITLE
Fix preview images

### DIFF
--- a/RTMSDF.uplugin
+++ b/RTMSDF.uplugin
@@ -18,12 +18,12 @@
 		{
 			"Name": "RTMSDFEditor",
 			"Type": "Editor",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "PreDefault"
 		},
 		{
 			"Name": "ChlumskyMSDFGen",
 			"Type": "Editor",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "PreDefault"
 		}
 	] 
 }


### PR DESCRIPTION
In some cases the asset was loaded before the editor and would warn
Warning: [AssetLog] D:\Capes\UnrealEngine\<myproject>\Content\Capes\UI\Icons_MSDF\T_Pause.uasset: Failed to load '/Script/RTMSDFEditor': Can't find file.