### PR TITLE
Fix compile error: `result type of conditional expression is ambiguous`

### DIFF
--- a/Source/RTMSDFEditor/Private/Importer/RTMSDFTextureSettingsCache.h
+++ b/Source/RTMSDFEditor/Private/Importer/RTMSDFTextureSettingsCache.h
@@ -44,8 +44,8 @@ struct FRTMSDFTextureSettingsCache
 
 		// restore if there is a new value, or set to default value
 #define CACHE(field, defaultValue) field = texture ? texture->field : defaultValue
-		CACHE(AddressX, TA_Clamp);
-		CACHE(AddressY, TA_Clamp);
+		CACHE(AddressX, TEnumAsByte<TextureAddress>(TA_Clamp));
+		CACHE(AddressY, TEnumAsByte<TextureAddress>(TA_Clamp));
 #undef  CACHE
 
 #define CACHE(field) field = texture ? texture->field : defaultTexture->field;


### PR DESCRIPTION
```
7>RTMSDFTextureSettingsCache.h(47): Error C2445 : result type of conditional expression is ambiguous: types 'const TEnumAsByte<TextureAddress>' and 'TextureAddress' can be converted to multiple common types
7>RTMSDFTextureSettingsCache.h(47): Reference C2445 : could be 'const TEnumAsByte<TextureAddress>'
7>RTMSDFTextureSettingsCache.h(47): Reference C2445 : or       'TextureAddress'
```